### PR TITLE
Add scRGB HDR support and improve SDR/HDR10 support

### DIFF
--- a/Shaders/ColorConversion.fxh
+++ b/Shaders/ColorConversion.fxh
@@ -21,10 +21,28 @@ https://creativecommons.org/publicdomain/mark/1.0/
 | :: Macros :: |
 '-------------*/
 
+// These are from the "color_space" enum in ReShade.
+// They can be compared against "BUFFER_COLOR_SPACE", which is defined by ReShade shaders.
+#ifndef RESHADE_COLOR_SPACE_UNKNOWN
+#define RESHADE_COLOR_SPACE_UNKNOWN     0
+#endif
+#ifndef RESHADE_COLOR_SPACE_SRGB
+#define RESHADE_COLOR_SPACE_SRGB        1
+#endif
+#ifndef RESHADE_COLOR_SPACE_SCRGB
+#define RESHADE_COLOR_SPACE_SCRGB       2
+#endif
+#ifndef RESHADE_COLOR_SPACE_BT2020_PQ
+#define RESHADE_COLOR_SPACE_BT2020_PQ   3
+#endif
+
 #ifndef ITU_REC
-	#define ITU_REC 601
-	// #define ITU_REC 709
-	// #define ITU_REC 2020
+#if BUFFER_COLOR_SPACE == RESHADE_COLOR_SPACE_BT2020_PQ
+	#define ITU_REC 2020
+#else
+	#define ITU_REC 709
+	//#define ITU_REC 601
+#endif
 #endif
 
 /*----------------.

--- a/Shaders/LinearGammaWorkflow.fxh
+++ b/Shaders/LinearGammaWorkflow.fxh
@@ -17,6 +17,21 @@ https://creativecommons.org/publicdomain/mark/1.0/
 
 #pragma once
 
+// These are from the "color_space" enum in ReShade.
+// They can be compared against "BUFFER_COLOR_SPACE", which is defined by ReShade shaders.
+#ifndef RESHADE_COLOR_SPACE_UNKNOWN
+#define RESHADE_COLOR_SPACE_UNKNOWN     0
+#endif
+#ifndef RESHADE_COLOR_SPACE_SRGB
+#define RESHADE_COLOR_SPACE_SRGB        1
+#endif
+#ifndef RESHADE_COLOR_SPACE_SCRGB
+#define RESHADE_COLOR_SPACE_SCRGB       2
+#endif
+#ifndef RESHADE_COLOR_SPACE_BT2020_PQ
+#define RESHADE_COLOR_SPACE_BT2020_PQ   3
+#endif
+
 /*----------------.
 | :: Functions :: |
 '----------------*/
@@ -24,14 +39,14 @@ https://creativecommons.org/publicdomain/mark/1.0/
 namespace GammaConvert
 {
 	// Convert display gamma for all vector types
-	#if BUFFER_COLOR_SPACE<=2 // transform from and to sRGB gamma
+	#if BUFFER_COLOR_SPACE==RESHADE_COLOR_SPACE_UNKNOWN || BUFFER_COLOR_SPACE==RESHADE_COLOR_SPACE_SRGB // transform from and to sRGB gamma in SDR (and fall back to it in the unknown color space case)
 		// Sourced from International Color Consortium, at https://color.org/chardata/rgb/srgb.xalter
-		#define _TO_DISPLAY_GAMMA(g) ((g)<=0.0031308?  (g)*12.92 : exp(log(abs(g))/2.4)*1.055-0.055)
-		#define _TO_LINEAR_GAMMA(g)  ((g)<=0.04049936? (g)/12.92 : exp(log((abs(g)+0.055)/1.055)*2.4))
-//	#elif BUFFER_COLOR_SPACE==3 // transform from and to HDR10 ST 2084
-		// #define _TO_DISPLAY_GAMMA(g) (exp(log(abs((0.8359375+18.8515625*exp(log(abs(g))*0.1593017578125))/(1f+18.6875*exp(log(abs(g))*0.1593017578125))))*78.84375))
-		// #define _TO_LINEAR_GAMMA(g)  (exp(log(abs(max(exp(log(abs(g))*32f/2523f)-0.8359375, 0f)/(18.8515625-18.6875*exp(log(abs(g))*32f/2523f))))*8192f/1305f))
-	#else // bypass transform
+		#define _TO_DISPLAY_GAMMA(g) ((g)<=0.0031308?  (g)*12.92 : exp(log(g)/2.4)*1.055-0.055)
+		#define _TO_LINEAR_GAMMA(g)  ((g)<=0.04049936? (g)/12.92 : exp(log((g+0.055)/1.055)*2.4))
+	#elif BUFFER_COLOR_SPACE==RESHADE_COLOR_SPACE_BT2020_PQ // transform from and to HDR10 ST 2084
+		#define _TO_DISPLAY_GAMMA(g) (exp(log(abs((0.8359375+18.8515625*exp(log(abs(g))*0.1593017578125))/(1f+18.6875*exp(log(abs(g))*0.1593017578125))))*78.84375))
+		#define _TO_LINEAR_GAMMA(g)  (exp(log(abs(max(exp(log(abs(g))*32f/2523f)-0.8359375, 0f)/(18.8515625-18.6875*exp(log(abs(g))*32f/2523f))))*8192f/1305f))
+	#else // bypass transform (e.g. BUFFER_COLOR_SPACE==RESHADE_COLOR_SPACE_SCRGB which is linear in/out)
 		#define _TO_DISPLAY_GAMMA(g) (g)
 		#define _TO_LINEAR_GAMMA(g)  (g)
 	#endif

--- a/Shaders/PerfectPerspective.fx
+++ b/Shaders/PerfectPerspective.fx
@@ -358,7 +358,11 @@ texture2D BackBufferMipTarget_Tex
 	Height = BUFFER_HEIGHT;
 
 	// Storing linear gamma picture in higher bit depth
+#if (BUFFER_COLOR_SPACE == RESHADE_COLOR_SPACE_SRGB) || (BUFFER_COLOR_SPACE == RESHADE_COLOR_SPACE_BT2020_PQ)
 	Format = RGB10A2;
+#else // BUFFER_COLOR_SPACE == RESHADE_COLOR_SPACE_SCRGB // Fall back on a higher quality in any other case, for future compatibility
+	Format = RGBA16F;
+#endif
 
 	// Maximum MIP map level
 	#if MIPMAPPING_LEVEL>0 && MIPMAPPING_LEVEL<=4
@@ -879,8 +883,14 @@ float3 PerfectPerspective_PS(
 
 	// Manually correct gamma
 	display = GammaConvert::to_display(display);
-	// Dither final 8/10-bit result
+	
+#if BUFFER_COLOR_SPACE == RESHADE_COLOR_SPACE_SRGB
+	// Dither final 8/10-bit result in SDR
 	return BlueNoise::dither(display, uint2(pixelPos.xy));
+#else
+	// Don't dither in HDR modes, it shouldn't be necessary due to the higher quality of input, and the display
+    return display;
+#endif
 }
 
 /* >> Output << */


### PR DESCRIPTION
scRGB HDR (linear) was clipping due to dithering at the end, and due to the UNORM texture being used as intermediary.
HDR10 PQ was disabled (untested, but I think it's fine?)
SDR was seemingly assuming the Rec.601 color space? That color space hasn't been used on displays for years so defaulting to Rec.709 sounds like a better choice.
Open to feedback :). Thanks!